### PR TITLE
Cleanup on `vnode stop`

### DIFF
--- a/vantage6/node/__init__.py
+++ b/vantage6/node/__init__.py
@@ -28,10 +28,9 @@ from threading import Thread
 from socketIO_client import SocketIO, SocketIONamespace
 from gevent.pywsgi import WSGIServer
 
-# TODO: relative import
-from . import globals as cs
-
 from vantage6.common.docker_addons import ContainerKillListener
+from vantage6.common.globals import VPN_CONFIG_FILE
+from vantage6.node.globals import NODE_PROXY_SERVER_HOSTNAME
 from vantage6.node.server_io import NodeClient
 from vantage6.node.proxy_server import app
 from vantage6.node.util import logger_name
@@ -189,7 +188,7 @@ class Node(object):
         if ctx.running_in_docker:
             isolated_network_mgr.connect(
                 container_name=ctx.docker_container_name,
-                aliases=[cs.NODE_PROXY_SERVER_HOSTNAME]
+                aliases=[NODE_PROXY_SERVER_HOSTNAME]
             )
 
         # Thread for sending results to the server when they come available.
@@ -218,9 +217,9 @@ class Node(object):
         os.environ["SERVER_PATH"] = self.server_io.path
 
         if self.ctx.running_in_docker:
-            # cs.NODE_PROXY_SERVER_HOSTNAME points to the name of the proxy
+            # NODE_PROXY_SERVER_HOSTNAME points to the name of the proxy
             # when running in the isolated docker network.
-            default_proxy_host = cs.NODE_PROXY_SERVER_HOSTNAME
+            default_proxy_host = NODE_PROXY_SERVER_HOSTNAME
         else:
             # If we're running non-dockerized, assume that the proxy is
             # accessible from within the docker algorithm container on
@@ -488,7 +487,7 @@ class Node(object):
             return
 
         # write ovpn config to node docker volume
-        ovpn_file = os.path.join(self.ctx.data_dir, cs.VPN_CONFIG_FILE)
+        ovpn_file = os.path.join(self.ctx.data_dir, VPN_CONFIG_FILE)
         with open(ovpn_file, 'w') as f:
             f.write(ovpn_config)
 

--- a/vantage6/node/__init__.py
+++ b/vantage6/node/__init__.py
@@ -589,6 +589,7 @@ class Node(object):
             self.log.info("Vnode is interrupted, shutting down...")
             self.socketIO.disconnect()
             self.vpn_manager.exit_vpn()
+            self.__docker.cleanup()
             sys.exit()
 
 

--- a/vantage6/node/docker/docker_manager.py
+++ b/vantage6/node/docker/docker_manager.py
@@ -236,6 +236,19 @@ class DockerManager(object):
         })
         return bool(running_containers)
 
+    def cleanup(self) -> None:
+        """
+        Stop all active tasks and delete the isolated network
+
+        Note: the temporary docker volumes are kept as they may still be used
+        by a master container
+        """
+        self.log.debug(f'Killing {len(self.active_tasks)} active task(s)')
+        while self.active_tasks:
+            task = self.active_tasks.pop()
+            task.cleanup(kill_algorithm=True)
+        self.isolated_network_mgr.cleanup()
+
     def run(self, result_id: int,  image: str, docker_input: bytes,
             tmp_vol_name: str, token: str) -> Union[int, None]:
         """

--- a/vantage6/node/docker/network_manager.py
+++ b/vantage6/node/docker/network_manager.py
@@ -1,22 +1,34 @@
 import docker
-import ipaddress
 import logging
 
-from vantage6.node.globals import LOCAL_SUBNET_START
 from vantage6.node.util import logger_name
 from vantage6.node.docker.utils import running_in_docker
 
 
 # TODO maybe move following to utils?
-def remove_subnet_mask(ip):
+def remove_subnet_mask(ip: str) -> str:
+    """
+    Remove the subnet mask of an ip address, e.g. 172.1.0.0/16 -> 172.1.0.0
+    """
     return ip[0:ip.find('/')]
 
 
 class IsolatedNetworkManager(object):
+    """
+    Handle the isolated docker network
+    """
 
     log = logging.getLogger(logger_name(__name__))
 
-    def __init__(self, network_name):
+    def __init__(self, network_name: str):
+        """
+        Initialize the IsolatedNetworkManager
+
+        Parameters
+        ----------
+        network_name: str
+            Name of the isolated network
+        """
         self.network_name = network_name
 
         # Connect to docker daemon
@@ -30,11 +42,6 @@ class IsolatedNetworkManager(object):
         Creates an internal (docker) network
 
         Used by algorithm containers to communicate with the node API.
-
-        Parameters
-        ----------
-        network_name: str
-            Name of the network to be created
 
         Returns
         -------
@@ -76,6 +83,14 @@ class IsolatedNetworkManager(object):
         self.isolated_network.connect(
             container_name, aliases=aliases, ipv4_address=ipv4
         )
+
+    def cleanup(self):
+        """ Delete the isolated network """
+        try:
+            self.isolated_network.remove()
+        except Exception as e:
+            self.log.error("Could not remove isolated network")
+            self.log.error(e)
 
     def get_container_ip(self, container_name: str) -> str:
         """

--- a/vantage6/node/docker/vpn_manager.py
+++ b/vantage6/node/docker/vpn_manager.py
@@ -7,11 +7,11 @@ from json.decoder import JSONDecodeError
 from typing import List, Union, Dict
 from docker.models.containers import Container
 
-from vantage6.common.globals import APPNAME
+from vantage6.common.globals import APPNAME, VPN_CONFIG_FILE
 from vantage6.node.util import logger_name
 from vantage6.node.globals import (
     MAX_CHECK_VPN_ATTEMPTS, NETWORK_CONFIG_IMAGE, VPN_CLIENT_IMAGE,
-    VPN_CONFIG_FILE, VPN_SUBNET, FREE_PORT_RANGE
+    VPN_SUBNET, FREE_PORT_RANGE
 )
 from vantage6.node.docker.network_manager import IsolatedNetworkManager
 

--- a/vantage6/node/globals.py
+++ b/vantage6/node/globals.py
@@ -34,6 +34,5 @@ VPN_CLIENT_IMAGE = 'algorithm-container-network_openvpn-client'
 NETWORK_CONFIG_IMAGE = 'network-config'
 VPN_SUBNET = '10.76.0.0/16'
 VPN_CONFIG_FILE = 'data/vpn-config.ovpn.conf'
-LOCAL_SUBNET_START = '172.'   # start of local IP addresses
 MAX_CHECK_VPN_ATTEMPTS = 60   # max attempts to obtain VPN IP (1 second apart)
 FREE_PORT_RANGE = range(49152, 65535)

--- a/vantage6/node/globals.py
+++ b/vantage6/node/globals.py
@@ -1,9 +1,5 @@
 from pathlib import Path
-from vantage6.common.globals import (
-    APPNAME,
-    STRING_ENCODING
-)
-
+from vantage6.common.globals import APPNAME
 
 #
 #   NODE SETTINGS
@@ -33,6 +29,5 @@ DATA_FOLDER = PACAKAGE_FOLDER / APPNAME / "_data"
 VPN_CLIENT_IMAGE = 'algorithm-container-network_openvpn-client'
 NETWORK_CONFIG_IMAGE = 'network-config'
 VPN_SUBNET = '10.76.0.0/16'
-VPN_CONFIG_FILE = 'data/vpn-config.ovpn.conf'
 MAX_CHECK_VPN_ATTEMPTS = 60   # max attempts to obtain VPN IP (1 second apart)
 FREE_PORT_RANGE = range(49152, 65535)

--- a/vantage6/node/proxy_server.py
+++ b/vantage6/node/proxy_server.py
@@ -22,7 +22,6 @@ from vantage6.node.util import (
     base64s_to_bytes,
     bytes_to_base64s
 )
-from vantage6.node.globals import STRING_ENCODING
 from vantage6.node.server_io import ClientNodeProtocol
 from vantage6.client.encryption import CryptorBase, DummyCryptor, RSACryptor
 
@@ -30,6 +29,7 @@ from vantage6.client.encryption import CryptorBase, DummyCryptor, RSACryptor
 app = Flask(__name__)
 log = logging.getLogger(logger_name(__name__))
 app.config["SERVER_IO"] = None
+
 
 def server_info():
     """ Retrieve proxy server details environment variables set by the
@@ -141,6 +141,7 @@ def proxy_task():
 
     return jsonify(response.json())
 
+
 @app.route('/task/<int:id>/result', methods=["GET"])
 def proxy_task_result(id):
     url = server_info()
@@ -174,6 +175,7 @@ def proxy_task_result(id):
 
     return jsonify(unencrypted)
 
+
 @app.route('/result/<int:id>', methods=["GET"])
 def proxy_results(id):
     """ Obtain result `id` from the server.
@@ -206,7 +208,9 @@ def proxy_results(id):
 
     return jsonify(response.json())
 
-@app.route('/<path:central_server_path>', methods=["GET", "POST", "PATCH", "PUT", "DELETE"])
+
+@app.route('/<path:central_server_path>',
+           methods=["GET", "POST", "PATCH", "PUT", "DELETE"])
 def proxy(central_server_path):
     """ Generic endpoint that will forward everything to the central server.
 
@@ -255,6 +259,6 @@ def proxy(central_server_path):
 
     if response.status_code > 200:
         log.error(f"server response code {response.status_code}")
-        log.debug(response.json().get("msg","no description..."))
+        log.debug(response.json().get("msg", "no description..."))
 
     return jsonify(response.json())


### PR DESCRIPTION
When node is stopped, now also stopping algorithm containers (if there are any still running) and removing isolated network. Implemented as discussed in IKNL/vantage6-main#24. 
