### PR TITLE
Added extra checks if labels are defined in the Dockerfile

### DIFF
--- a/vantage6/node/docker/vpn_manager.py
+++ b/vantage6/node/docker/vpn_manager.py
@@ -299,7 +299,7 @@ class VPNManager(DockerBaseManager):
             return default_ports
 
         # find any labels defined in the docker image
-        labels = []
+        labels = {}
         try:
             labels = n2n_image.attrs['Config']['Labels']
         except KeyError:
@@ -314,7 +314,13 @@ class VPNManager(DockerBaseManager):
                 self.log.warn("Could not parse port specified in algorithm "
                               f"docker image {image}: {port}")
             # get port label: this should be defined as 'p1234' for port 1234
-            label = labels.get('p' + port)
+            label = None
+            if labels:
+                label = labels.get('p' + port)
+            if not label:
+                self.log.warn(f"No label defined in image for port {port}. "
+                              "Algorithm will not be able to find the port "
+                              "using the label!")
             ports.append({'algo_port': port, 'label': label})
 
         if not ports:


### PR DESCRIPTION
Fix IKNL/vantage6-main#184 (all parts have been completed if this PR is approved)

I ran into an issue running an older image where a port was defined but no label. For those cases, there is now a warning, but ports are then generated as usual. This will allow algorithms to generate multiple ports without labels. Which ports are used for what purpose is of course the responsibility of the algorithm developer.