### PR TITLE
Hotfix/vpn connect old config

### DIFF
--- a/vantage6/node/__init__.py
+++ b/vantage6/node/__init__.py
@@ -559,7 +559,7 @@ class Node(object):
         """
         ovpn_file = os.path.join(self.__vpn_dir, VPN_CONFIG_FILE)
 
-        self.log.debug("Setting up VPN client container")
+        self.log.info("Setting up VPN client container")
         vpn_volume_name = self.ctx.docker_vpn_volume_name \
             if ctx.running_in_docker else self.__vpn_dir
         vpn_manager = VPNManager(

--- a/vantage6/node/docker/vpn_manager.py
+++ b/vantage6/node/docker/vpn_manager.py
@@ -81,6 +81,12 @@ class VPNManager(DockerBaseManager):
             devices=['/dev/net/tun'],
         )
 
+        # check successful initiation of VPN connection
+        if self.has_connection():
+            self.log.info("VPN client container was successfully started!")
+        else:
+            raise ConnectionError("VPN connection not established!")
+
         # attach vpnclient to isolated network
         self.log.debug("Connecting VPN client container to isolated network")
         self.isolated_network_mgr.connect(
@@ -96,12 +102,6 @@ class VPNManager(DockerBaseManager):
                            "interface of isolated network")
             return
         self._configure_host_network()
-
-        # check successful initiation of VPN connection
-        if self.has_connection():
-            self.log.info("VPN client container was successfully started!")
-        else:
-            raise ConnectionError("VPN connection not established!")
 
     def has_connection(self) -> bool:
         """ Return True if VPN connection is active """

--- a/vantage6/node/docker/vpn_manager.py
+++ b/vantage6/node/docker/vpn_manager.py
@@ -97,28 +97,31 @@ class VPNManager(DockerBaseManager):
             return
         self._configure_host_network()
 
-        # set successful initiation of VPN connection
-        self.has_vpn = True
-        self.log.debug("VPN client container was started")
+        # check successful initiation of VPN connection
+        if self.has_connection():
+            self.log.info("VPN client container was successfully started!")
+        else:
+            raise ConnectionError("VPN connection not established!")
 
     def has_connection(self) -> bool:
         """ Return True if VPN connection is active """
-        if not self.has_vpn:
-            return False
-        # check if the VPN container has an IP address in the VPN namespace
-        try:
-            # if there is a VPN connection, the following command will return
-            # a json vpn interface. If not, it will return "Device "tun0" does
-            # not exist."
-            _, vpn_interface = self.vpn_client_container.exec_run(
-                'ip --json addr show dev tun0'
-            )
-            vpn_interface = json.loads(vpn_interface)
-        except JSONDecodeError:
-            self.has_vpn = False
-            return False
-        self.has_vpn = True  # TODO rid boolean and only use this function?
-        return True
+        self.log.debug("Waiting for VPN connection. This may take a minute...")
+        n_attempt = 0
+        self.has_vpn = False
+        while n_attempt < MAX_CHECK_VPN_ATTEMPTS:
+            n_attempt += 1
+            try:
+                _, vpn_interface = self.vpn_client_container.exec_run(
+                    'ip --json addr show dev tun0'
+                )
+                vpn_interface = json.loads(vpn_interface)
+                self.has_vpn = True
+                break
+            except (JSONDecodeError, docker.errors.APIError):
+                # JSONDecodeError if VPN is not setup yet, APIError if VPN
+                # container is restarting (e.g. due to connection errors)
+                time.sleep(1)
+        return self.has_vpn
 
     def exit_vpn(self) -> None:
         """
@@ -158,21 +161,16 @@ class VPNManager(DockerBaseManager):
         str
             IP address assigned to VPN client container by VPN server
         """
-        # VPN might not be fully set up at this point. Therefore, poll to
-        # check. When it is ready, extract the IP address.
-        n_attempt = 0
-        while n_attempt < MAX_CHECK_VPN_ATTEMPTS:
-            n_attempt += 1
-            try:
-                _, vpn_interface = self.vpn_client_container.exec_run(
-                    'ip --json addr show dev tun0'
-                )
-                vpn_interface = json.loads(vpn_interface)
-                break
-            except (JSONDecodeError, docker.errors.APIError):
-                # JSONDecodeError if VPN is not setup yet, APIError if VPN
-                # container is restarting (e.g. due to connection errors)
-                time.sleep(1)
+        try:
+            _, vpn_interface = self.vpn_client_container.exec_run(
+                'ip --json addr show dev tun0'
+            )
+            vpn_interface = json.loads(vpn_interface)
+        except (JSONDecodeError, docker.errors.APIError):
+            # JSONDecodeError if VPN is not setup yet, APIError if VPN
+            # container is restarting (e.g. due to connection errors)
+            raise ConnectionError(
+                "Could not get VPN IP: VPN is not connected!")
         return vpn_interface[0]['addr_info'][0]['local']
 
     def forward_vpn_traffic(self, helper_container: Container,


### PR DESCRIPTION
This is an improvement in checking whether a VPN connection can be established. The intended flow (first try existing config file, then refresh keypair, then renew entire file) was not working because it was not detected when VPN could not be established. This is fixed here. 

Fix IKNL/vantage6-main#161 